### PR TITLE
Updates base image to phusion:focal-1.0.0

### DIFF
--- a/Dockerfile.app
+++ b/Dockerfile.app
@@ -1,4 +1,4 @@
-FROM vgmdb_reqs:36a64e
+FROM vgmdb_reqs:0b51ca
 
 # install vgmdb software
 ADD vgmdb /vgmdb

--- a/Dockerfile.reqs
+++ b/Dockerfile.reqs
@@ -1,9 +1,9 @@
-FROM phusion/baseimage:0.9.15
+FROM phusion/baseimage:bionic-1.0.0
 
 # setting up the baseimage
 ENV HOME=/root
 RUN rm /etc/my_init.d/*ssh*
-RUN rm -r /etc/service/sshd /etc/service/cron /etc/service/syslog-ng
+RUN rm -r /etc/service/sshd /etc/service/cron
 
 # install nginx
 RUN apt-get update; apt-get install -y nginx
@@ -11,6 +11,10 @@ RUN echo "daemon off;" >> /etc/nginx/nginx.conf
 RUN mkdir /etc/service/nginx
 ADD docker/sv-nginx /etc/service/nginx/run
 ADD docker/nginx-site.conf /etc/nginx/sites-enabled/default
+
+# explicitly install vgmdb runtime requirements, to avoid
+# removal in apt-get autoremove.
+RUN apt-get install -y libpython2.7 libxml2 libxslt1.1 zlib1g
 
 # install vgmdb requirements
 RUN apt-get install -y python-dev python-pip libxml2-dev libxslt1-dev zlib1g-dev git


### PR DESCRIPTION
This image is based on Ubuntu 18.04 (previous was
Ubuntu 14.04). Previously, the reqs image was not
buildable - I believe this is due to the older
Python experiencing SSL errors on pypi.org (though
to be honest, I didn't spent a lot of time finding
out the *exact* cause).

This also manually installs some dependencies, since
running `apt-get autoremove python-dev` will actually
remove `libpython2.7`.

As far as I can tell, everything is functioning as
designed after this update.