### PR TITLE
parses calendar link text on album pages

### DIFF
--- a/vgmdb/parsers/album.py
+++ b/vgmdb/parsers/album.py
@@ -158,6 +158,8 @@ def _parse_album_info(soup_info):
 					date = soup_value.a['href'].split('#')[1]
 					if date.isdigit():
 						album_info['release_date'] = '%s-%s-%s'%(date[0:4], date[4:6], date[6:8])
+					else: # link to calendar, but date is ambiguous (Jul 1997)
+						album_info['release_date'] = utils.parse_date_time(soup_value.a.string)
 					soup_event = soup_value.a.find_next_sibling('a')
 				else:			# freeform text
 					album_info['release_date'] = soup_value.value


### PR DESCRIPTION
Example: https://vgmdb.net/album/4106 is just listed as "Jul 1997"
but has a link to a calendar like
`https://vgmdb.net/db/calendar.php?year=1997&month=7#unknown`

In the case of `#unknown` the album parser runs the link text ("Jul
1997") through the parse_date_time method.